### PR TITLE
Handle windows using DPI sclaing > 1.0

### DIFF
--- a/PlaylistFilterForSpotify/src/App/App.cpp
+++ b/PlaylistFilterForSpotify/src/App/App.cpp
@@ -255,6 +255,11 @@ void App::extendPinsByRecommendations()
     renderer.highlightWindow("Pin Recommendations");
 };
 
+const Renderer& App::getRenderer()
+{
+    return renderer;
+};
+
 //
 //
 //

--- a/PlaylistFilterForSpotify/src/App/App.h
+++ b/PlaylistFilterForSpotify/src/App/App.h
@@ -32,6 +32,8 @@ class App
     void createPlaylist(const std::vector<Track*>& tracks);
     void extendPinsByRecommendations();
 
+    const Renderer& getRenderer();
+
     // todo: make private, add get and/or set
 
     std::vector<Track> playlist;

--- a/PlaylistFilterForSpotify/src/Renderer/Renderer.h
+++ b/PlaylistFilterForSpotify/src/Renderer/Renderer.h
@@ -31,7 +31,17 @@ class Renderer
     Renderer& operator=(Renderer&& other) = delete; // move assign
     ~Renderer();
     void init();
+
     void draw();
+
+    void rebuildBuffer();
+    void highlightWindow(const std::string& name);
+
+    template <typename T>
+    inline T scaleByDPI(T in) const
+    {
+        return in * dpiScale;
+    }
 
     // todo: make private
     // Window Settings
@@ -59,9 +69,6 @@ class Renderer
     GLuint debugLinesPointBuffer = 0;
     int debugLinesPointBufferSize = 0;
     bool uiHidden = false;
-
-    void rebuildBuffer();
-    void highlightWindow(const std::string& name);
 
   private:
     void fillTrackBuffer(int i1, int i2, int i3);


### PR DESCRIPTION
UI is incredibly small on my laptop with higher res and 2.0x windows default DPI
this PR adjusts the font size and other layout to take the current dpi into account

atm only checks the dpi once on window creation but it could be adjusted to also use a callback for any DPI changes